### PR TITLE
Supports the Promise object returned by the .play() method

### DIFF
--- a/bideo.js
+++ b/bideo.js
@@ -56,8 +56,13 @@
       self.videoEl.addEventListener('canplay', function () {
         // Play the video when enough has been buffered
         if (!self.opt.isMobile) {
-          self.opt.onLoad && self.opt.onLoad();
-          if (self.opt.autoplay !== false) self.videoEl.play();
+          var playPromise;
+          
+          if (self.opt.autoplay !== false) {
+            playPromise = self.videoEl.play();
+          }
+
+          self.opt.onLoad && self.opt.onLoad(playPromise);
         }
       });
 

--- a/main.js
+++ b/main.js
@@ -32,8 +32,12 @@
     ],
 
     // What to do once video loads (initial frame)
-    onLoad: function () {
-      document.querySelector('#video_cover').style.display = 'none';
+    onLoad: function (playPromise) {
+      if (playPromise !== undefined) {
+        playPromise.then(function () {
+          document.querySelector('#video_cover').style.display = 'none';
+        });
+      }
     }
   });
 }());


### PR DESCRIPTION
Since Chrome M66 lauched an Autoplay Policy, the `play()` method returns a `Promise` that
must be verified to hide the video cover correctly.

More info: [https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#audiovideo_elements](https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#audiovideo_elements)